### PR TITLE
Bugfix/htt client/return type hint break changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.4.0",
         "ext-json": "*",
-        "psr/http-client": "1.0.*",
+        "psr/http-client": "1.0.1",
         "psr/log": "1.1.*",
         "guzzlehttp/guzzle": "6.*|7.*",
         "symfony/serializer": "4.4.*|5.4.*",

--- a/src/Testing/TestClient.php
+++ b/src/Testing/TestClient.php
@@ -10,9 +10,9 @@ class TestClient implements ClientInterface
 {
     /** @var array<RequestHandlerInterface>  */
     private array $handlers;
-    private RequestHandlerInterface $defaultHandler;
+    private ?RequestHandlerInterface $defaultHandler;
 
-    public function __construct(RequestHandlerInterface $defaultHandler, array $handlers = [])
+    public function __construct(array $handlers = [], ?RequestHandlerInterface $defaultHandler = null)
     {
         $this->setDefaultHandler($defaultHandler);
         $this->setHandlers($handlers);
@@ -37,19 +37,19 @@ class TestClient implements ClientInterface
         return $this->handlers;
     }
 
-    public function getDefaultHandler(): RequestHandlerInterface
+    public function getDefaultHandler(): ?RequestHandlerInterface
     {
         return $this->defaultHandler;
     }
 
-    public function setDefaultHandler(RequestHandlerInterface $defaultHandler): void
+    public function setDefaultHandler(?RequestHandlerInterface $defaultHandler): void
     {
         $this->defaultHandler = $defaultHandler;
     }
 
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
-        return ($this->findHandler($request) ?? $this->defaultHandler)->handle($request);
+        return ($this->findHandler($request) ?? $this->defaultHandler ?? $this->createEmptyHandler())->handle($request);
     }
 
     private function findHandler(RequestInterface $request): ?RequestHandlerInterface
@@ -60,6 +60,11 @@ class TestClient implements ClientInterface
             }
         }
         return null;
+    }
+
+    private function createEmptyHandler(): RequestHandlerInterface
+    {
+        return new RequestHandler(fn() => '');
     }
 
     /**

--- a/tests/RestClientTest.php
+++ b/tests/RestClientTest.php
@@ -3,13 +3,11 @@
 namespace RestClient\Tests;
 
 use PHPStan\Testing\TestCase;
-use Psr\Http\Message\RequestInterface;
 use RestClient\Configuration\DefaultConfiguration;
 use RestClient\DefaultJsonRestClient;
 use RestClient\RestClient;
 use RestClient\RestClientInterface;
 use RestClient\Serialization\Symfony\JsonSymfonySerializer;
-use RestClient\Testing\RequestHandler;
 use RestClient\Testing\TestClient;
 use RestClient\Tests\Dto\MessageDto;
 use RestClient\Tests\Dto\OrderDto;
@@ -21,7 +19,7 @@ class RestClientTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        $handlers = [
+        $testClient = new TestClient([
             'GET?uri=/test/message' => '{"message": "ok"}',
             'GET?matcher=re&uri=/\/customer\/\d+\/orders/' => [
                 'json' => [
@@ -41,12 +39,7 @@ class RestClientTest extends TestCase
                     'name' => 'car'
                 ]
             ]
-        ];
-
-        $testClient = new TestClient(
-            new RequestHandler(fn (RequestInterface $request) => 'NOK'),
-            $handlers
-        );
+        ]);
 
         static::$restClient = new RestClient($testClient, new JsonSymfonySerializer());
     }


### PR DESCRIPTION
В http-client 1.0.2 добавили return type hint , которые ломают работу 